### PR TITLE
compatibility：panic when running test3C #469. 

### DIFF
--- a/scheduler/server/config/config.go
+++ b/scheduler/server/config/config.go
@@ -610,7 +610,7 @@ func (c *Config) GenEmbedEtcdConfig() (*embed.Config, error) {
 	cfg.WalDir = ""
 	cfg.InitialCluster = c.InitialCluster
 	cfg.ClusterState = c.InitialClusterState
-	cfg.EnablePprof = true
+	cfg.EnablePprof = false
 	cfg.StrictReconfigCheck = !c.DisableStrictReconfigCheck
 	cfg.TickMs = uint(c.TickInterval.Duration / time.Millisecond)
 	cfg.ElectionMs = uint(c.ElectionInterval.Duration / time.Millisecond)


### PR DESCRIPTION
related issue #469

compatibility：panic when running test3C #469.  

Set cfg.EnablePprof to false in scheduler/server/config/config.go GenEmbedEtcdConfig()